### PR TITLE
Added a few more options and ordered users by date of last post

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: thewanderingbrit
 Donate link: https://www.theukedge.com/donate/?utm_source=wordpress.org&utm_medium=plugin&utm_campaign=donate
 Tags: authors, recent, contributors, widget, month, week, day
 Requires at least: 3.7
-Tested up to: 4.5.2
-Stable tag: 1.2
+Tested up to: 4.9.7
+Stable tag: 1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,16 @@ Probably. The best thing to do is to create a new feature request on [GitHub](ht
 2. The widget control panel
 
 == Changelog ==
+
+= 1.3 =
+
+Release date: July 13, 2018
+
+* Order contributors by date of last post, reverse-cronological
+* Add option to show/hide the contributor’s avatar
+* Add option to show/hide the contributor’s name
+* Add option to blacklist users from the recent contributors list by user id
+* Update call to get users to filter out subscribers and limit the fields returned to only those needed
 
 = 1.2 =
 

--- a/recent-contributors-widget.php
+++ b/recent-contributors-widget.php
@@ -141,16 +141,18 @@ class recent_contributors_widget extends WP_Widget {
 			if( $linkdestination == 'posts_list' ) {
 				$link = get_author_posts_url( $author->ID );
 				$link_rel = "";
+				$link_title = __("Posts by $author->display_name", 'recent-contributors-widget');
 			} elseif( $linkdestination == 'website' ) {
 				$link = get_the_author_meta( 'user_url', $author->ID );
 				$link_rel = "external nofollow";
+				$link_title = __("$author->display_name's Website", 'recent-contributors-widget');
 			}
 		?>
 			<li>
 				<div class="recent-contributor vcard">
 				<?php if( $avatar ): ?>
 					<?php if( $link ): ?>
-						<a class="url" href="<?php echo $link; ?>"><?php echo $avatar; ?></a>
+						<a class="url" href="<?php echo $link; ?>" title="<?php echo $link_title; ?>"><?php echo $avatar; ?></a>
 					<?php else: ?>
 						<?php echo $avatar; ?>
 					<?php endif; ?>
@@ -159,7 +161,7 @@ class recent_contributors_widget extends WP_Widget {
 					<span class="fn n">
 						<span class="screen-reader-text"><?php _e( 'Author ', 'recent-contributors-widget' ); ?></span>
 						<?php if( $link ): ?>
-							<a href="<?php echo $link; ?>" rel="<?php echo $link_rel; ?>" class="url"><?php echo $name; ?></a>
+							<a href="<?php echo $link; ?>" title="<?php echo $link_title; ?>" rel="<?php echo $link_rel; ?>" class="url"><?php echo $name; ?></a>
 						<?php else: ?>
 							<?php echo $name; ?>
 						<?php endif; ?>

--- a/recent-contributors-widget.php
+++ b/recent-contributors-widget.php
@@ -103,6 +103,7 @@ class recent_contributors_widget extends WP_Widget {
 				while($query->have_posts()) {
 					$query->the_post();
 					$author->last_post = get_the_date('U');
+					$author->found_posts = $query->found_posts;
 				}
 				wp_reset_postdata();
 			} else {
@@ -167,7 +168,7 @@ class recent_contributors_widget extends WP_Widget {
 				<?php if( $postcount ): ?>
 					<span class="post-count">
 						<span class="screen-reader-text"><?php _e( 'Post count ', 'recent-contributors-widget' ); ?></span>
-						(<?php echo $query->post_count; ?>)
+						(<?php echo $author->found_posts; ?>)
 					</span>
 				<?php endif; ?>
 				</div>

--- a/recent-contributors.css
+++ b/recent-contributors.css
@@ -1,0 +1,3 @@
+.recent-contributor img {
+	vertical-align: middle;
+}


### PR DESCRIPTION
I really like this plugin, so I added a few features.

* Order contributors by date of last post in reverse-cronological order
* Add option to show/hide the contributor’s avatar
* Add option to show/hide the contributor’s name
* Add option to blacklist users from the recent contributors list by user id
* Update call to get users to filter out subscribers and limit the fields returned to only those needed

Let me know if you'd like to pull this in or if you'd like me to change some stuff.